### PR TITLE
Fix repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/shouldjs/spromised.git"
+    "url": "git://github.com/shouldjs/promised.git"
   },
   "keywords": [
     "should",


### PR DESCRIPTION
It was pointing at https://github.com/shouldjs/spromised.git; I changed it to point at https://github.com/shouldjs/promised.git.
