### PR TITLE
Added basic fulfilledWith(expectedValue) functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ it('should be allow to check if promise fulfilled', function() {
 });
 ```
 
+## .fulfilledWith
+
+Assert given promise will be fulfilled with an expected value. It will return promise.
+
+```
+it('should be allow to check if promise fulfilledWith an expected value', function() {
+  return promised(10).should.be.fulfilledWith(10);
+});
+```
+
 ## .rejected
 
 Assert given promise will be rejected. It will return promise.

--- a/should-promised.js
+++ b/should-promised.js
@@ -98,6 +98,37 @@
   });
 
   /**
+   * Assert given promise will be fulfilled with some expected value.
+   *
+   * @name fulfilledWith
+   * @memberOf Assertion
+   * @category assertion promises
+   * @module should-promised
+   * @returns {Promise}
+   * @example
+   * (new Promise(function(resolve, reject) { resolve(10); })).should.be.fulfilledWith(10);
+   */
+  should.Assertion.prototype.fulfilledWith = function(expectedValue) {
+    this.params = {operator: 'to be fulfilled'};
+
+    this.obj.should.be.a.Promise;
+
+    var that = this;
+    return this.obj.then(function (value) {
+      if(that.negate) {
+        that.fail();
+      }
+      value.should.eql(expectedValue);
+      return value;
+    }, function next$onError(err) {
+      if(!that.negate) {
+        that.fail();
+      }
+      return err;
+    });
+  };
+
+  /**
    * Assert given promise will be rejected with some sort of error. Arguments is the same for Assertion#throw
    *
    * @name rejectedWith

--- a/test/promised.test.js
+++ b/test/promised.test.js
@@ -66,6 +66,23 @@ it('should be allow to check if promise fulfilled', function() {
   ]);
 });
 
+it('should be allow to check if promise is fulfilledWith a value', function() {
+  return Promise.all([
+    promised(10).should.be.fulfilledWith(10), //positive
+    promiseFail().should.be.fulfilledWith(10).then(function(value) {//negative
+      should.fail();
+    }, function(err) {
+      err.should.be.Error.and.match({message: 'expected [Promise] to be fulfilled'});
+    }),
+    promised(10).should.not.be.fulfilledWith(10).then(function(value) {//positive fail
+      should.fail();
+    }, function(err) {
+      err.should.be.Error.and.match({message: 'expected [Promise] not to be fulfilled'});
+    }),
+    promiseFail().should.not.be.fulfilledWith(10)//negative fail
+  ]);
+});
+
 it('should be allow to check if promise rejected', function() {
   return Promise.all([
     promiseFail().should.be.rejected, //positive


### PR DESCRIPTION
I added the ability to call `should.be.fulfilledWith()` and pass a value. Currently the assertion checking uses `.eql()` which could be changed to `.equal()`, or you could add functionality to `fulfilledWith()` to accept arguments such as flag to enable strict checking or a callback that actually does the equality checking itself.

I figured I'd leave those details up to the author though and just add a basic implementation.
